### PR TITLE
added files.parsefss.com for ATS warning: Application Transport Secur…

### DIFF
--- a/CocoaHeadsNL/CocoaHeadsNL/Info.plist
+++ b/CocoaHeadsNL/CocoaHeadsNL/Info.plist
@@ -6,6 +6,11 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>files.parsetfss.com</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+			</dict>
 			<key>is2.mzstatic.com</key>
 			<dict>
 				<key>NSIncludesSubdomains</key>


### PR DESCRIPTION
…ity has blocked a cleartext HTTP resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file.
