### PR TITLE
The UITableViewDelegate in DetailDataSource was missing methods

### DIFF
--- a/CocoaHeadsNL/CocoaHeadsNL/DetailDataSource.swift
+++ b/CocoaHeadsNL/CocoaHeadsNL/DetailDataSource.swift
@@ -67,4 +67,12 @@ class DetailDataSource: NSObject, UITableViewDataSource, UITableViewDelegate {
         cell.urlString = urlString
         return cell
     }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableViewAutomaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return CGFloat(88)
+    }
 }

--- a/CocoaHeadsNL/CocoaHeadsNL/HTMLDataCell.swift
+++ b/CocoaHeadsNL/CocoaHeadsNL/HTMLDataCell.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class HTMLDataCell: UITableViewCell {
     
-    @IBOutlet weak var heighLayoutConstraint: NSLayoutConstraint!
     @IBOutlet weak var textView: UITextView!
     
     var html: String? {


### PR DESCRIPTION
The UITableViewDelegate in DetailDataSource was missing methods thus not laying out correctly. This fixes that.

Also removed a leftover constraint that was not being used anymore.