### PR TITLE
Add Today section in meetup list

### DIFF
--- a/CocoaHeadsNL/CocoaHeadsNL/MeetupCell.swift
+++ b/CocoaHeadsNL/CocoaHeadsNL/MeetupCell.swift
@@ -57,9 +57,9 @@ class MeetupCell: UITableViewCell {
             dateFormatter.dateFormat = "MMMM"
             monthLabel.accessibilityLabel = dateFormatter.string(from: date as Date)
 
-            if date.timeIntervalSinceNow > 0 {
+            if meetup.isToday || meetup.isUpcoming {
                 dayLabel.textColor = UIColor.black
-                calendarView.backgroundColor = UIColorWithRGB(232, green: 88, blue: 80)
+                calendarView.backgroundColor = meetup.isToday ? UIColorWithRGB(127, green: 214, blue: 33) : UIColorWithRGB(232, green: 88, blue: 80)
 
 
                 if meetup.yes_rsvp_count.int32Value > 0{

--- a/CocoaHeadsNL/CocoaHeadsNL/MeetupsViewController.swift
+++ b/CocoaHeadsNL/CocoaHeadsNL/MeetupsViewController.swift
@@ -37,8 +37,11 @@ class MeetupsViewController: UITableViewController, UIViewControllerPreviewingDe
 
                 let year = Calendar.current.component(.year, from: meetupTime)
                 let yearString: String
-                
-                if meetupTime.timeIntervalSince(Date()) > 0 {
+
+                if meetup.isToday {
+                    yearString = NSLocalizedString("Today", comment: "Section title for todays meetup.")
+                }
+                else if meetup.isUpcoming {
                     yearString = NSLocalizedString("Upcoming", comment: "Section title for upcoming meetups.")
                 } else {
                     yearString = "\(year)"
@@ -64,7 +67,19 @@ class MeetupsViewController: UITableViewController, UIViewControllerPreviewingDe
     
     fileprivate var sectionTitles: [String] {
         get {
-            return meetupsByYear.keys.sorted().reversed()
+            let sections = meetupsByYear.keys
+            let today = sections.filter { $0 == NSLocalizedString("Today", comment: "Section title for todays meetup.") }
+            let upcoming = sections.filter { $0 == NSLocalizedString("Upcoming", comment: "Section title for upcoming meetups.") }
+
+            let rest = sections
+                .filter { section in
+                    return section != NSLocalizedString("Today", comment: "Section title for todays meetup.")
+                        && section != NSLocalizedString("Upcoming", comment: "Section title for upcoming meetups.")
+                }
+                .sorted()
+                .reversed()
+
+            return today + upcoming + rest
         }
     }
     

--- a/CocoaHeadsNL/CocoaHeadsNL/ModelObjects.swift
+++ b/CocoaHeadsNL/CocoaHeadsNL/ModelObjects.swift
@@ -302,6 +302,19 @@ class Meetup: Object {
         }
     }()
 
+    var isToday: Bool {
+        guard let time = time else { return false }
+
+        let today = dateOnlyFormatter.string(from: Date())
+        return dateOnlyFormatter.string(from: time) == today
+    }
+
+    var isUpcoming: Bool {
+        guard let time = time else { return false }
+
+        return time.timeIntervalSinceNow > 0
+    }
+
     @available(iOS 9.0, *)
     var searchableAttributeSet: CSSearchableItemAttributeSet {
         get {
@@ -370,3 +383,15 @@ class Meetup: Object {
         }
     }
 }
+
+private let dateOnlyFormatter: DateFormatter = {
+    let amsterdam = TimeZone(identifier: "Europe/Amsterdam")!
+    let nl_NL = Locale(identifier: "nl-NL")
+
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.locale = nl_NL
+    dateFormatter.timeZone = amsterdam
+
+    return dateFormatter
+}()


### PR DESCRIPTION
Today's meetup is prominently shown on top of the list of meetups. Instead of dropping of of the list immediately after it has scheduled to start (but before I've arrived at the location).

<img width="555" alt="screen shot 2018-04-25 at 23 43 20" src="https://user-images.githubusercontent.com/75655/39274690-107ecc3e-48e3-11e8-9334-f1ad62ceccd9.png">
